### PR TITLE
fix install for native module on mac

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -62,7 +62,7 @@ download() {
   if fetch "${url}" > fruzzy_mod.so; then
     return
   else
-    warn "Binary not found."
+    warn "Binary not found, please wait for a few minutes."
   fi
 }
 
@@ -73,6 +73,6 @@ arch=$(uname -sm)
 case "${arch}" in
   "Linux x86_64") download fruzzy_mod.so ;;
   "Linux i686") download fruzzy_mod.so ;;
-  "Darwin x86_64") download fruzzy_mod.so ;;
+  "Darwin x86_64") download fruzzy_mod_mac.so ;;
   *) info "No pre-built binary available for ${arch}.";;
 esac


### PR DESCRIPTION
Current binary file not works on mac, as described at #2.
I've uploaded the binary for mac at https://github.com/raghur/fruzzy/files/2433524/fruzzy.zip
it need to be unzipped and upload to the release page as `fruzzy_mod_mac.so`