### PR TITLE
Set match limit to 1000

### DIFF
--- a/rplugin/python3/denite/filter/matcher/fruzzymatcher.py
+++ b/rplugin/python3/denite/filter/matcher/fruzzymatcher.py
@@ -15,6 +15,10 @@ if pkgPath not in sys.path:
 
 import fruzzy
 
+
+LIMIT = 1000
+
+
 class Filter(Base):
 
     def __init__(self, vim):
@@ -53,13 +57,11 @@ class Filter(Base):
         # self.debug("context: %s" % context)
         ispath = candidates and 'action__path' in candidates[0]
         # self.debug("candidates %s %s" % (qry, len(candidates)))
-        limit = context['winheight']
-        limit = int(limit) if isinstance(limit, str) else limit
         buffer = context['bufnr']
         buffer = int(buffer) if isinstance(buffer, str) else buffer
         sortOnEmptyQuery = self.vim.vars.get("fruzzy#sortonempty", 1)
         results = self.scoreMatchesProxy(qry, candidates,
-                                         limit,
+                                         LIMIT,
                                          key=lambda x: x['word'],
                                          ispath=ispath,
                                          buffer=buffer,


### PR DESCRIPTION
Constraining the match limit to winheight provides the user too few matches.

Raising the limit to 1,000 makes the plugin behavior consistent with other filters, e.g., [cpsm](https://github.com/Shougo/denite.nvim/blob/7d54f44e1035aea4cba99bdb34f0565b55008706/rplugin/python3/denite/filter/matcher/cpsm.py#L65).